### PR TITLE
speckit: Issue番号からブランチ自動作成に対応

### DIFF
--- a/.claude/skills/speckit-git-feature/SKILL.md
+++ b/.claude/skills/speckit-git-feature/SKILL.md
@@ -21,6 +21,34 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## GitHub Issue Detection (Auto-Detection)
+
+Before anything else, scan the feature description (user input / `$ARGUMENTS`) for an Issue number using the following patterns **in priority order**:
+
+1. **GitHub Issue URL** — e.g. `https://github.com/<owner>/<repo>/issues/9`
+   - Regex: `https?://github\.com/[^/]+/[^/]+/issues/(\d+)`
+2. **Hash prefix** — e.g. `#9`
+   - Regex: `#(\d+)` (standalone, not inside a URL)
+3. **issues/ path** — e.g. `issues/9`
+   - Regex: `\bissues/(\d+)\b`
+
+If any pattern matches, extract the issue number `N` and set:
+
+```
+GIT_BRANCH_NAME=feature/issues-N
+```
+
+Then proceed as if the user explicitly provided `GIT_BRANCH_NAME` (see below).
+
+**Examples**:
+
+| User writes | Auto-detected branch |
+|---|---|
+| `社員一覧 #9` | `feature/issues-9` |
+| `https://github.com/org/repo/issues/9 社員一覧を作りたい` | `feature/issues-9` |
+| `社員一覧 issues/9` | `feature/issues-9` |
+| `社員一覧` (no issue number) | sequential: `feature/002-employee-list` |
+
 ## Environment Variable Override
 
 If the user explicitly provided `GIT_BRANCH_NAME` (e.g., via environment variable, argument, or in their request), pass it through to the script by setting the `GIT_BRANCH_NAME` environment variable before invoking the script. When `GIT_BRANCH_NAME` is set:

--- a/.specify/extensions/git/git-config.yml
+++ b/.specify/extensions/git/git-config.yml
@@ -8,6 +8,10 @@ branch_numbering: sequential
 # Leave blank or omit to disable.
 branch_prefix: feature
 
+# Base branch to checkout and pull from before creating a new feature branch.
+# Leave blank or omit to skip auto-checkout/pull.
+base_branch: develop
+
 # Commit message used by `git commit` during repository initialization
 init_commit_message: "[Spec Kit] Initial commit"
 

--- a/.specify/extensions/git/scripts/bash/create-new-feature.sh
+++ b/.specify/extensions/git/scripts/bash/create-new-feature.sh
@@ -385,6 +385,22 @@ elif [ "$BRANCH_BYTE_LEN" -gt $MAX_BRANCH_LENGTH ]; then
     >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
 fi
 
+if [ "$DRY_RUN" != true ] && [ "$HAS_GIT" = true ]; then
+    # Checkout and pull base branch before creating feature branch
+    _GIT_CONFIG="$REPO_ROOT/.specify/extensions/git/git-config.yml"
+    if [ -f "$_GIT_CONFIG" ]; then
+        _BASE_BRANCH=$(grep -E '^base_branch:' "$_GIT_CONFIG" | sed 's/^base_branch:[[:space:]]*//' | tr -d '"' | tr -d "'" | xargs)
+        if [ -n "$_BASE_BRANCH" ] && [ "$_BASE_BRANCH" != "null" ]; then
+            >&2 echo "[specify] Switching to base branch '$_BASE_BRANCH' and pulling latest..."
+            if git checkout -q "$_BASE_BRANCH" 2>/dev/null; then
+                git pull --ff-only 2>/dev/null || >&2 echo "[specify] Warning: pull failed, proceeding with local state"
+            else
+                >&2 echo "[specify] Warning: could not checkout '$_BASE_BRANCH', creating branch from current HEAD"
+            fi
+        fi
+    fi
+fi
+
 if [ "$DRY_RUN" != true ]; then
     if [ "$HAS_GIT" = true ]; then
         branch_create_error=""

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -144,9 +144,14 @@ check_feature_branch() {
     if [[ "$branch" =~ ^[0-9]{3,}- ]] && [[ ! "$branch" =~ ^[0-9]{7}-[0-9]{6}- ]] && [[ ! "$branch" =~ ^[0-9]{7,8}-[0-9]{6}$ ]]; then
         is_sequential=true
     fi
-    if [[ "$is_sequential" != "true" ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
+    # Accept GitHub issue-style branches: issues-{number}
+    local is_issue=false
+    if [[ "$branch" =~ ^issues-[0-9]+$ ]]; then
+        is_issue=true
+    fi
+    if [[ "$is_sequential" != "true" ]] && [[ "$is_issue" != "true" ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
         echo "ERROR: Not on a feature branch. Current branch: $raw" >&2
-        echo "Feature branches should be named like: 001-feature-name, 1234-feature-name, or 20260319-143022-feature-name" >&2
+        echo "Feature branches should be named like: 001-feature-name, issues-6, or 20260319-143022-feature-name" >&2
         return 1
     fi
 


### PR DESCRIPTION
## 概要

- `feature/issues-N` 形式のブランチ命名に対応
- `/speckit-specify` 実行時に説明文から Issue 番号を自動検出してブランチを作成

## 変更内容

- **`.specify/extensions/git/git-config.yml`**: `branch_prefix: feature`、`base_branch: develop` を追加
- **`create-new-feature.sh`**: `branch_prefix` 読み取りと `base_branch` の自動 checkout/pull を追加
- **`common.sh`**: `issues-N` パターンをブランチ検証に追加
- **`speckit-git-feature/SKILL.md`**: Issue 番号自動検出ロジックを追加（`#N`、GitHub URL、`issues/N` の3パターン）

## 動作

```
/speckit-specify #10 社員詳細機能を作りたい
→ ブランチ: feature/issues-10 が自動作成
```

Closes #9